### PR TITLE
Fix children attribute to be a list of FileNode objects

### DIFF
--- a/backend/app/services/file_service.py
+++ b/backend/app/services/file_service.py
@@ -12,7 +12,7 @@ def get_relationships(file_node_list: List[FileNode]) -> List[FileEdge]:
     for file_node in file_node_list:
         if file_node.children:
             for child in file_node.children:
-                relationships.append(FileEdge(source=file_node.name, target=child))
+                relationships.append(FileEdge(source=file_node.name, target=child.name))
     return relationships
 
 
@@ -68,7 +68,12 @@ def get_file_info(file_path: FilePath, all_file_path_list: List[FilePath], index
             target = target_file_path.full
             if normalized_import == target.replace('/', '.').replace('.py', ''):
                 # 絶対パスを追加
-                children.append(str(Path(full_path).parent / target))
+                child_node = FileNode(
+                    id=str(index) + "_" + Path(target).name,
+                    name=str(Path(full_path).parent / target),
+                    type='file'
+                )
+                children.append(child_node)
 
     file_node = FileNode(
         id=str(index) + "_" + path.name,  # IDとしてファイルのパスを使用

--- a/backend/tests/test_file_service.py
+++ b/backend/tests/test_file_service.py
@@ -41,5 +41,15 @@ class TestFileService(unittest.TestCase):
             get_files_info()
         mock_logger.error.assert_called_with('Error getting files: Test error')
 
+    @patch('app.services.file_service.get_python_file_path_list')
+    def test_get_file_info_children(self, mock_get_python_file_path_list):
+        mock_get_python_file_path_list.return_value = [
+            FilePath(full="test.py", base=".", relative="test.py"),
+            FilePath(full="imported_module.py", base=".", relative="imported_module.py")
+        ]
+        file_info = get_files_info()
+        self.assertIsInstance(file_info[0].children, list)
+        self.assertIsInstance(file_info[0].children[0], FileNode)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Update `get_file_info` function to create `FileNode` objects for the `children` attribute instead of string paths.

* **backend/app/services/file_service.py**
  - Modify the `get_file_info` function to create `FileNode` objects for the `children` attribute.
  - Update the `relationships` list to append `FileEdge` objects with `child.name` instead of `child`.

* **backend/tests/test_file_service.py**
  - Add a test case to verify that the `children` attribute is a list of `FileNode` objects.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/nobu007/llm_code_navigator/pull/2?shareId=88a2efdd-a922-44f3-a7d1-a63fdd0f1cf6).