### PR TITLE
Add CI pipeline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
-
-.PHONY = deps up down destroy all help
+.PHONY = deps up down destroy all help ci
 
 # デフォルトターゲットを最初に定義
 .DEFAULT_GOAL := help
@@ -36,6 +35,9 @@ destroy: deps
 # すべてのターゲットを実行
 all: deps destroy up
 
+ci: deps
+	docker-compose run --rm ci
+
 ######################
 # HELP
 ######################
@@ -47,3 +49,4 @@ help:
 	@echo 'down				- stop llm_code_navigator'
 	@echo 'destroy          - remove docker images'
 	@echo 'all              - start after destroy'
+	@echo 'ci               - run CI pipeline locally using Docker'

--- a/backend/.github/workflows/ci.yml
+++ b/backend/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.10
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r backend/requirements.txt
+
+      - name: Run tests
+        run: |
+          python -m unittest discover -s backend/tests
+
+      - name: Build Docker image
+        run: |
+          docker build -t llm_code_navigator-backend ./backend

--- a/backend/tests/test_file_service.py
+++ b/backend/tests/test_file_service.py
@@ -51,5 +51,23 @@ class TestFileService(unittest.TestCase):
         self.assertIsInstance(file_info[0].children, list)
         self.assertIsInstance(file_info[0].children[0], FileNode)
 
+    @patch('app.services.file_service.get_file_content')
+    def test_get_file_content_file_not_found(self, mock_get_file_content):
+        mock_get_file_content.side_effect = FileNotFoundError("Test file not found")
+        with self.assertRaises(FileNotFoundError):
+            get_file_content("non_existent_file.py")
+
+    @patch('app.services.file_service.get_file_content')
+    def test_get_file_content_permission_error(self, mock_get_file_content):
+        mock_get_file_content.side_effect = PermissionError("Test permission error")
+        with self.assertRaises(PermissionError):
+            get_file_content("restricted_file.py")
+
+    @patch('app.services.file_service.get_file_content')
+    def test_get_file_content_general_exception(self, mock_get_file_content):
+        mock_get_file_content.side_effect = Exception("Test general exception")
+        with self.assertRaises(Exception):
+            get_file_content("some_file.py")
+
 if __name__ == '__main__':
     unittest.main()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,19 @@ services:
     hostname: frontend
     entrypoint: ["npm", "run", "dev"]
 
+  ci:
+    image: llm_code_navigator-backend
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+    volumes:
+      - ./work:/app/work
+    environment:
+      - BACKEND_DIR=/app/work
+    networks:
+      - app-network
+    entrypoint: ["python", "-m", "unittest", "discover", "-s", "backend/tests"]
+
 networks:
   app-network:
     driver: bridge


### PR DESCRIPTION
Implement a basic CI pipeline using GitHub Actions, Makefile, and Docker Compose.

* **GitHub Actions Workflow:**
  - Add `backend/.github/workflows/ci.yml` to define the CI pipeline.
  - Configure the workflow to run on push and pull request events.
  - Include steps to set up Python, install dependencies, run tests, and build the Docker image.

* **Makefile:**
  - Add a `ci` target to run the CI pipeline locally using Docker.

* **Docker Compose:**
  - Add a `ci` service in `docker-compose.yml` for running the CI pipeline.

* **Unit Tests:**
  - Add additional unit tests in `backend/tests/test_file_service.py` for `file_service.py` functions.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/nobu007/llm_code_navigator/pull/3?shareId=0491b4e1-662e-4398-804d-0c01b71fbbb5).