### PR TITLE
Add CI for frontend

### DIFF
--- a/backend/.github/workflows/ci.yml
+++ b/backend/.github/workflows/ci.yml
@@ -30,6 +30,34 @@ jobs:
         run: |
           python -m unittest discover -s backend/tests
 
+      - name: Run Docker Compose CI service
+        run: |
+          docker-compose -f docker-compose.yml run --rm ci
+
       - name: Build Docker image
         run: |
           docker build -t llm_code_navigator-backend ./backend
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '16'
+
+      - name: Install frontend dependencies
+        run: |
+          cd frontend
+          npm install
+
+      - name: Run frontend tests
+        run: |
+          cd frontend
+          npm test
+
+      - name: Build frontend Docker image
+        run: |
+          docker build -t llm_code_navigator-frontend ./frontend
+
+      - name: Run frontend linting
+        run: |
+          cd frontend
+          npm run lint

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -4,5 +4,6 @@ WORKDIR /app/frontend
 
 COPY . .
 RUN ./install.sh
+RUN npm install jest
 
 CMD ["npm", "run", "dev"]

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "jest" // P3cd9
   },
   "dependencies": {
     "@chakra-ui/icons": "^2.1.1",


### PR DESCRIPTION
Add steps to GitHub Actions workflow to run frontend tests, build frontend Docker image, and run frontend linting.

* **GitHub Actions Workflow (`backend/.github/workflows/ci.yml`)**
  - Add step to run Docker Compose CI service.
  - Add step to set up Node.js.
  - Add step to install frontend dependencies.
  - Add step to run frontend tests using `npm test`.
  - Add step to build frontend Docker image.
  - Add step to run frontend linting using `npm run lint`.

* **Frontend Package Configuration (`frontend/package.json`)**
  - Add `test` script to run frontend tests using `jest`.

* **Frontend Dockerfile (`frontend/Dockerfile`)**
  - Add step to install `jest` for running frontend tests.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/nobu007/llm_code_navigator/pull/4?shareId=ea1b4882-614a-454d-9a1a-442994964fa2).