### PR TITLE
Fix workflow to run backend tests using Docker Compose

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,9 +30,9 @@ jobs:
         run: |
           python -m unittest discover -s backend/tests
 
-      - name: Run Docker Compose CI service
+      - name: Run backend tests using Docker Compose
         run: |
-          docker-compose -f docker-compose.yml run --rm ci
+          docker-compose -f docker-compose.yml run --rm backend
 
       - name: Build Docker image
         run: |

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -7,4 +7,4 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 
-CMD ["python", "-m", "app:app"]
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "9000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
       - app-network
     hostname: backend
     entrypoint: ["python", "-m", "app.main"]
+    command: ["python", "-m", "unittest", "discover", "-s", "backend/tests"]
 
   frontend:
     build:
@@ -28,19 +29,6 @@ services:
       - app-network
     hostname: frontend
     entrypoint: ["npm", "run", "dev"]
-
-  ci:
-    image: llm_code_navigator-backend
-    build:
-      context: ./backend
-      dockerfile: Dockerfile
-    volumes:
-      - ./work:/app/work
-    environment:
-      - BACKEND_DIR=/app/work
-    networks:
-      - app-network
-    entrypoint: ["python", "-m", "unittest", "discover", "-s", "backend/tests"]
 
 networks:
   app-network:


### PR DESCRIPTION
Update the CI workflow to run backend tests using Docker Compose.

* **backend/Dockerfile**
  - Change the `CMD` instruction to use `uvicorn` to run the app.

* **.github/workflows/ci.yml**
  - Remove the step to run Docker Compose CI service.
  - Add a new step to run backend tests using Docker Compose.

* **docker-compose.yml**
  - Add a `command` instruction to the `backend` service to run tests.
  - Remove the `ci` service definition.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/nobu007/llm_code_navigator/pull/6?shareId=b9116355-f72f-4895-b67d-6d81dc61843e).