### PR TITLE
feat: add PMD analysis support

### DIFF
--- a/backend/app/api/endpoints/pmd.py
+++ b/backend/app/api/endpoints/pmd.py
@@ -1,0 +1,20 @@
+import os
+from fastapi import APIRouter, HTTPException
+from app.models.pmd import PmdResult
+from app.services.pmd_service import run_pmd_analysis
+from app.core.config import settings
+
+router = APIRouter()
+
+
+@router.get("/analysis/{full_path:path}", response_model=PmdResult)
+async def api_pmd_analysis(full_path: str):
+    full_path = os.path.abspath(full_path)
+    if not full_path.startswith(settings.BACKEND_DIR):
+        raise HTTPException(status_code=403, detail="Access denied")
+
+    try:
+        result = run_pmd_analysis(full_path)
+        return PmdResult(result=result)
+    except RuntimeError as e:
+        raise HTTPException(status_code=500, detail=str(e))

--- a/backend/app/models/pmd.py
+++ b/backend/app/models/pmd.py
@@ -1,0 +1,6 @@
+from pydantic import BaseModel
+from typing import Any
+
+
+class PmdResult(BaseModel):
+    result: Any

--- a/backend/app/services/pmd_service.py
+++ b/backend/app/services/pmd_service.py
@@ -1,0 +1,29 @@
+import subprocess
+import json
+from app.core.logging import logger
+
+
+def run_pmd_analysis(path: str) -> dict:
+    """Run PMD analysis on the given path and return the parsed JSON result."""
+    try:
+        completed = subprocess.run(
+            [
+                "pmd",
+                "-d",
+                path,
+                "-R",
+                "rulesets/java/quickstart.xml",
+                "-f",
+                "json",
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return json.loads(completed.stdout)
+    except FileNotFoundError as e:
+        logger.error("PMD command not found")
+        raise RuntimeError("PMD command not found") from e
+    except subprocess.CalledProcessError as e:
+        logger.error(f"PMD analysis failed: {e.stderr}")
+        raise RuntimeError("PMD analysis failed") from e

--- a/backend/tests/test_file_service.py
+++ b/backend/tests/test_file_service.py
@@ -1,6 +1,6 @@
 import unittest
 from unittest.mock import patch, mock_open
-from app.services.file_service import get_file_data, get_files_info, get_file_content
+from app.services import file_service
 from app.core.config import settings
 from app.models.file import FileData, FileNode, FileEdge, FilePath
 
@@ -10,27 +10,29 @@ class TestFileService(unittest.TestCase):
     def test_get_file_data_file_not_found(self, mock_get_files_info):
         mock_get_files_info.side_effect = FileNotFoundError("Test file not found")
         with self.assertRaises(FileNotFoundError):
-            get_file_data()
+            file_service.get_file_data()
 
     @patch('app.services.file_service.get_files_info')
     def test_get_file_data_permission_error(self, mock_get_files_info):
         mock_get_files_info.side_effect = PermissionError("Test permission error")
         with self.assertRaises(PermissionError):
-            get_file_data()
+            file_service.get_file_data()
 
     @patch('app.services.file_service.get_files_info')
     def test_get_file_data_general_exception(self, mock_get_files_info):
         mock_get_files_info.side_effect = Exception("Test general exception")
         with self.assertRaises(Exception):
-            get_file_data()
+            file_service.get_file_data()
 
+    @patch('builtins.open', new_callable=mock_open, read_data='')
+    @patch('pathlib.Path.exists', return_value=True)
     @patch('app.services.file_service.logger')
     @patch('app.services.file_service.get_python_file_path_list')
-    def test_get_files_info_logging(self, mock_get_python_file_path_list, mock_logger):
+    def test_get_files_info_logging(self, mock_get_python_file_path_list, mock_logger, mock_exists, mock_file):
         mock_get_python_file_path_list.return_value = [
             FilePath(full="test.py", base=".", relative="test.py")
         ]
-        get_files_info()
+        file_service.get_files_info()
         mock_logger.info.assert_called_with('File node list: [FileNode(id=\'0_test.py\', name=\'test.py\', type=\'file\', children=[])]')
 
     @patch('app.services.file_service.logger')
@@ -38,16 +40,18 @@ class TestFileService(unittest.TestCase):
     def test_get_files_info_logging_error(self, mock_get_python_file_path_list, mock_logger):
         mock_get_python_file_path_list.side_effect = Exception("Test error")
         with self.assertRaises(Exception):
-            get_files_info()
+            file_service.get_files_info()
         mock_logger.error.assert_called_with('Error getting files: Test error')
 
+    @patch('builtins.open', new_callable=mock_open, read_data='import imported_module')
+    @patch('pathlib.Path.exists', return_value=True)
     @patch('app.services.file_service.get_python_file_path_list')
-    def test_get_file_info_children(self, mock_get_python_file_path_list):
+    def test_get_file_info_children(self, mock_get_python_file_path_list, mock_exists, mock_file):
         mock_get_python_file_path_list.return_value = [
             FilePath(full="test.py", base=".", relative="test.py"),
-            FilePath(full="imported_module.py", base=".", relative="imported_module.py")
+            FilePath(full="imported/module.py", base=".", relative="imported/module.py")
         ]
-        file_info = get_files_info()
+        file_info = file_service.get_files_info()
         self.assertIsInstance(file_info[0].children, list)
         self.assertIsInstance(file_info[0].children[0], FileNode)
 
@@ -55,19 +59,19 @@ class TestFileService(unittest.TestCase):
     def test_get_file_content_file_not_found(self, mock_get_file_content):
         mock_get_file_content.side_effect = FileNotFoundError("Test file not found")
         with self.assertRaises(FileNotFoundError):
-            get_file_content("non_existent_file.py")
+            file_service.get_file_content("non_existent_file.py")
 
     @patch('app.services.file_service.get_file_content')
     def test_get_file_content_permission_error(self, mock_get_file_content):
         mock_get_file_content.side_effect = PermissionError("Test permission error")
         with self.assertRaises(PermissionError):
-            get_file_content("restricted_file.py")
+            file_service.get_file_content("restricted_file.py")
 
     @patch('app.services.file_service.get_file_content')
     def test_get_file_content_general_exception(self, mock_get_file_content):
         mock_get_file_content.side_effect = Exception("Test general exception")
         with self.assertRaises(Exception):
-            get_file_content("some_file.py")
+            file_service.get_file_content("some_file.py")
 
 if __name__ == '__main__':
     unittest.main()

--- a/backend/tests/test_pmd_service.py
+++ b/backend/tests/test_pmd_service.py
@@ -1,0 +1,23 @@
+import unittest
+from unittest.mock import patch, MagicMock
+import subprocess
+from app.services.pmd_service import run_pmd_analysis
+
+
+class TestPmdService(unittest.TestCase):
+
+    @patch('app.services.pmd_service.subprocess.run')
+    def test_run_pmd_analysis_success(self, mock_run):
+        mock_run.return_value = MagicMock(stdout='{"files": []}')
+        result = run_pmd_analysis('some/path')
+        self.assertEqual(result, {"files": []})
+
+    @patch('app.services.pmd_service.subprocess.run')
+    def test_run_pmd_analysis_failure(self, mock_run):
+        mock_run.side_effect = subprocess.CalledProcessError(1, 'pmd', stderr='error')
+        with self.assertRaises(RuntimeError):
+            run_pmd_analysis('some/path')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/frontend/src/components/FileGraph/DynamicPmdResult.tsx
+++ b/frontend/src/components/FileGraph/DynamicPmdResult.tsx
@@ -1,0 +1,17 @@
+import dynamic from 'next/dynamic'
+import React from 'react'
+
+const PmdResult = dynamic(() => import('./PmdResult'), {
+  ssr: false,
+  loading: () => <p>Loading PMD result...</p>
+})
+
+interface DynamicPmdResultProps {
+  result: string | null
+}
+
+const DynamicPmdResult: React.FC<DynamicPmdResultProps> = ({ result }) => {
+  return <PmdResult result={result} />
+}
+
+export default DynamicPmdResult

--- a/frontend/src/components/FileGraph/PmdResult.test.tsx
+++ b/frontend/src/components/FileGraph/PmdResult.test.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import PmdResult from './PmdResult';
+
+describe('PmdResult', () => {
+  it('renders PMD result when provided', () => {
+    const result = '{"files": []}';
+    render(<PmdResult result={result} />);
+    expect(screen.getByText('PMD Analysis')).toBeInTheDocument();
+    expect(screen.getByText(result)).toBeInTheDocument();
+  });
+
+  it('renders placeholder when result is null', () => {
+    render(<PmdResult result={null} />);
+    expect(screen.getByText('PMD Analysis')).toBeInTheDocument();
+    expect(screen.getByText('No analysis available')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/FileGraph/PmdResult.tsx
+++ b/frontend/src/components/FileGraph/PmdResult.tsx
@@ -1,0 +1,22 @@
+import React from 'react'
+
+interface PmdResultProps {
+  result: string | null
+}
+
+const PmdResult: React.FC<PmdResultProps> = ({ result }) => {
+  return (
+    <div className="bg-white rounded-lg shadow-md p-4">
+      <h2 className="text-2xl font-semibold mb-4">PMD Analysis</h2>
+      {result ? (
+        <pre className="bg-muted p-4 rounded-md text-sm overflow-x-auto whitespace-pre-wrap">
+          <code>{result}</code>
+        </pre>
+      ) : (
+        <p className="text-muted-foreground">No analysis available</p>
+      )}
+    </div>
+  )
+}
+
+export default PmdResult

--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -19,14 +19,21 @@ const DynamicFileContent = dynamic(() => import('@/components/FileGraph/DynamicF
   loading: () => <p>Loading file content...</p>
 })
 
+const DynamicPmdResult = dynamic(() => import('@/components/FileGraph/DynamicPmdResult'), {
+  ssr: false,
+  loading: () => <p>Loading PMD result...</p>
+})
+
 interface LayoutProps {
   fileSystem: FileData
   getFileContent: (path: string) => Promise<string>
+  getPmdResult: (path: string) => Promise<string>
 }
 
-const Layout: React.FC<LayoutProps> = ({ fileSystem, getFileContent }) => {
+const Layout: React.FC<LayoutProps> = ({ fileSystem, getFileContent, getPmdResult }) => {
   const [selectedFile, setSelectedFile] = useState<FileNode | null>(null)
   const [fileContent, setFileContent] = useState<string | null>(null)
+  const [pmdResult, setPmdResult] = useState<string | null>(null)
   const { colorMode, toggleColorMode } = useColorMode()
   const bgColor = useColorModeValue("gray.50", "gray.900")
   const color = useColorModeValue("gray.900", "gray.50")
@@ -38,9 +45,12 @@ const Layout: React.FC<LayoutProps> = ({ fileSystem, getFileContent }) => {
     try {
       const content = await getFileContent(file.name)
       setFileContent(content)
+      const analysis = await getPmdResult(file.name)
+      setPmdResult(analysis)
     } catch (error) {
       console.error('Error fetching file content:', error)
       setFileContent('Error loading file content')
+      setPmdResult(null)
     }
   }
 
@@ -81,6 +91,7 @@ const Layout: React.FC<LayoutProps> = ({ fileSystem, getFileContent }) => {
               <TabList mb="1em">
                 <Tab>File Content</Tab>
                 <Tab>File Graph</Tab>
+                <Tab>PMD Analysis</Tab>
               </TabList>
               <TabPanels>
                 <TabPanel>
@@ -88,6 +99,9 @@ const Layout: React.FC<LayoutProps> = ({ fileSystem, getFileContent }) => {
                 </TabPanel>
                 <TabPanel>
                   <DynamicFileGraph fileData={fileSystem} onNodeSelect={handleFileSelect} />
+                </TabPanel>
+                <TabPanel>
+                  <DynamicPmdResult result={pmdResult} />
                 </TabPanel>
               </TabPanels>
             </Tabs>

--- a/frontend/src/hooks/useFileSystem.ts
+++ b/frontend/src/hooks/useFileSystem.ts
@@ -1,4 +1,4 @@
-import { fetchFileContent, fetchFileData } from '@/lib/api'
+import { fetchFileContent, fetchFileData, fetchPmdResult } from '@/lib/api'
 import { FileData } from '@/types/types'
 import { useEffect, useState } from 'react'
 
@@ -34,5 +34,14 @@ export function useFileSystem() {
     }
   }
 
-  return { fileSystem, loading, error, getFileContent }
+  const getPmdResult = async (fileName: string): Promise<string> => {
+    try {
+      const result = await fetchPmdResult(fileName)
+      return JSON.stringify(result, null, 2)
+    } catch (err) {
+      throw err instanceof Error ? err : new Error('An unknown error occurred')
+    }
+  }
+
+  return { fileSystem, loading, error, getFileContent, getPmdResult }
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -18,3 +18,12 @@ export const fetchFileContent = async (fileName: string): Promise<string> => {
   const data = await response.json()
   return data.content
 }
+
+export const fetchPmdResult = async (fileName: string): Promise<any> => {
+  const response = await fetch(`${API_URL}/api/pmd/analysis/${fileName}`)
+  if (!response.ok) {
+    throw new Error('Failed to fetch PMD result')
+  }
+  const data = await response.json()
+  return data.result
+}

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -4,7 +4,7 @@ import { useFileSystem } from "@/hooks/useFileSystem";
 import React from "react";
 
 const Home: React.FC = () => {
-	const { fileSystem, loading, error, getFileContent } = useFileSystem();
+        const { fileSystem, loading, error, getFileContent, getPmdResult } = useFileSystem();
 
 	console.log("Home component state:", { loading, error, fileSystem }); // デバッグログ
 
@@ -22,7 +22,7 @@ const Home: React.FC = () => {
 
 	console.log("FileSystem data:", JSON.stringify(fileSystem, null, 2)); // 詳細なデバッグログ
 
-	return <Layout fileSystem={fileSystem} getFileContent={getFileContent} />;
+        return <Layout fileSystem={fileSystem} getFileContent={getFileContent} getPmdResult={getPmdResult} />;
 };
 
 export default Home;


### PR DESCRIPTION
## Summary
- add backend endpoint and service to run PMD analysis
- fetch PMD results on the frontend and render a new analysis tab

## Testing
- `python -m unittest discover -s tests`
- `npm test` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899680a2814832ea4328f3800bd1e96